### PR TITLE
Substitution values must be in array

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ mailer
       }
     },
     sub: {
-      '{user_firstname}': 'Receiver',
-      '{user_lastname}': 'Smith',
-      '{user_age}': '28'
+      '{user_firstname}': ['Receiver'],
+      '{user_lastname}': ['Smith'],
+      '{user_age}': ['28']
     }
   })
   .property('subject', ' ') // subject is required by SendGrid


### PR DESCRIPTION
[SendGrid's](https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/smtpapi.html#-Substitutions-and-Sections) docs claim that the substitution parameter value must be an array.

Not as important now as it once was since Parse is being unwound, but it might help someone coming across this repo who has to use Parse in the short-term.
